### PR TITLE
Make some relative URLs absolute.

### DIFF
--- a/content/_footer.html.hbs
+++ b/content/_footer.html.hbs
@@ -3,5 +3,5 @@
     href="https://github.com/mkantor/operator-website/blob/master/content{{request-route}}.html.hbs"
     >This page</a
   >
-  is served by Operator. You can <a href="run-this-site">run it locally</a>.
+  is served by Operator. You can <a href="/run-this-site">run it locally</a>.
 </footer>

--- a/content/_header.html.hbs
+++ b/content/_header.html.hbs
@@ -1,5 +1,5 @@
 <header>
-  <h1><a href="home">Operator</a></h1>
+  <h1><a href="/home">Operator</a></h1>
   <nav>
     <ul>
       <li>

--- a/content/_page.html.hbs
+++ b/content/_page.html.hbs
@@ -6,9 +6,9 @@
     <title>Operator Web Server</title>
     <meta name="author" content="Matt Kantor" />
     <meta name="description" content="A web server for static and dynamic content." />
-    <link rel="stylesheet" href="stylesheets/normalize.css" />
-    <link rel="stylesheet" href="stylesheets/layout.css" />
-    <link rel="stylesheet" href="stylesheets/decoration.css" />
+    <link rel="stylesheet" href="/stylesheets/normalize.css" />
+    <link rel="stylesheet" href="/stylesheets/layout.css" />
+    <link rel="stylesheet" href="/stylesheets/decoration.css" />
   </head>
   <body>
     {{> @partial-block}}

--- a/content/features.html.hbs
+++ b/content/features.html.hbs
@@ -89,22 +89,22 @@
         href="https://github.com/mkantor/operator-website/blob/master/content/examples/negotiation/image.webp"
         ><code>image.webp</code></a
       >, the server will be able to satisfy
-      <a href="examples/negotiation/image"><code>GET /image</code></a> as either
+      <a href="/examples/negotiation/image"><code>GET /image</code></a> as either
       <code>image/png</code> or <code>image/webp</code>. "Negotiation" means
       that Operator uses the representation which best fits the client's
       preferences. For example, your browser prefers
       <img
         class="inline"
-        src="examples/negotiation/image"
+        src="/examples/negotiation/image"
         alt="Image in PNG or WebP format, depending on your browser."
       />.
     </p>
     <p>
       Request URLs with file extensions override the <code>Accept</code> header.
       For example, you can
-      <a href="examples/negotiation/image.png"><code>GET /image.png</code></a>
+      <a href="/examples/negotiation/image.png"><code>GET /image.png</code></a>
       or
-      <a href="examples/negotiation/image.webp"><code>GET /image.webp</code></a>
+      <a href="/examples/negotiation/image.webp"><code>GET /image.webp</code></a>
       to retrieve a specific type no matter which your browser prefers.
     </p>
   </article>


### PR DESCRIPTION
This makes content more agnostic of the request URI. For example I noticed that stylesheets would not load on the 404 page when the URI was something like <http://operator.mattkantor.com/a/b>.