### PR TITLE
Upgrade Operator to 0.1.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
-ARG operator_version=0.1.1
-ARG operator_hash=0bddea8f99f803ffba866fd7bff1f76b3260ccb77e9bcf7f72228c1a9361d14c
+ARG operator_version=0.1.2
+ARG operator_hash=6f1fe37a11e28f55c2c7ccc9844c9b6c692e9cb33ff73a3c938ed57f706d8ba1
 
 SHELL ["/bin/bash", "-c"]
 
@@ -11,7 +11,7 @@ WORKDIR /opt
 RUN \
   apt-get update \
     && apt-get -y install curl \
-    && curl --location --silent https://github.com/mkantor/operator/releases/download/${operator_version}/operator-linux.tar.gz \
+    && curl --location --silent https://github.com/mkantor/operator/releases/download/${operator_version}/operator-linux-x86-64.tar.gz \
       | tee operator.tar.gz \
       | sha256sum --check <(echo "${operator_hash}  -") \
     && apt-get -y purge curl \

--- a/content/_install-commands.html.hbs
+++ b/content/_install-commands.html.hbs
@@ -1,6 +1,6 @@
 {{#if (eq os "linux")}}
   <ul class="commands">
-      <li>curl -L https://github.com/mkantor/operator/releases/download/{{version}}/operator-{{os}}.tar.gz \
+      <li>curl -L https://github.com/mkantor/operator/releases/download/{{version}}/operator-{{os}}-x86-64.tar.gz \
   &gt; operator.tar.gz</li>
       <li>cat operator.tar.gz \
   | sha256sum -c &lt;(echo "{{hash}}  -") \
@@ -10,7 +10,7 @@
   </ul>
 {{else}}{{#if (eq os "macos")}}
   <ul class="commands">
-    <li>curl -L https://github.com/mkantor/operator/releases/download/{{version}}/operator-{{os}}.tar.gz \
+    <li>curl -L https://github.com/mkantor/operator/releases/download/{{version}}/operator-{{os}}-x86-64.tar.gz \
   &gt; operator.tar.gz</li>
     <li>cat operator.tar.gz \
   | shasum -a 256 -c &lt;(echo "{{hash}}  -") \

--- a/content/home.html.hbs
+++ b/content/home.html.hbs
@@ -42,8 +42,8 @@
         <summary>Linux <small>x86-64</small></summary>
         {{>_install-commands.html.hbs
           os="linux"
-          version="0.1.1"
-          hash="0bddea8f99f803ffba866fd7bff1f76b3260ccb77e9bcf7f72228c1a9361d14c"
+          version="0.1.2"
+          hash="6f1fe37a11e28f55c2c7ccc9844c9b6c692e9cb33ff73a3c938ed57f706d8ba1"
         }}
       </details>
 
@@ -51,8 +51,8 @@
         <summary>macOS <small>x86-64</small></summary>
         {{>_install-commands.html.hbs
           os="macos"
-          version="0.1.1"
-          hash="adcb356d80a8be4bb3343821e0f0a621a06b128f6c4a9936777990ad3b20580a"
+          version="0.1.2"
+          hash="75a813b51a09b8988b09561bb94cb87f21466dd4daadc0f72308f916f4f53746"
         }}
       </details>
     </div>


### PR DESCRIPTION
Now uses the new naming scheme for build artifacts.