### PR TITLE
Specify a platform (linux/amd64) for Debian base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG operator_version=0.3.0
 ARG operator_hash=47f30a639b8eb1c8ec57f6d66c2a2d0e7a5ff3822527277331094a8dfd239b5a


### PR DESCRIPTION
The version of Operator used in the image is compiled for x86-64. However, the Debian image is available for multiple platforms and there is ambiguity unless `--platform` is specified.

This came up now because I tried to build this image on Apple silicon for the first time. Docker defaults to the host platform's architecture and was pulling a Debian image which can't run the server.

I'll probably build Operator for this Apple silicon eventually, but even then it probably makes sense to default to x86-64 for this image.