### PR TITLE
Display `--help` output on the usage page.

### DIFF
--- a/content/_operator-help.html.mjs
+++ b/content/_operator-help.html.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { exec } from 'node:child_process'
+
+const renderData = JSON.parse(process.env.OPERATOR_RENDER_DATA)
+const operatorPath = renderData['server-info']['operator-path']
+const subcommand = renderData['subcommand']
+
+const escapeHtmlTextContent = (text) =>
+  text.replace(/[<>&]/g, (character) => {
+    switch (character) {
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '&': return '&amp;'
+    }
+  })
+
+const childProcess = exec(
+  subcommand === undefined
+    ? `"${operatorPath}" --help`
+    : `"${operatorPath}" "${subcommand}" --help`,
+)
+
+process.stdout.write('<pre>')
+for await (const helpChunk of childProcess.stdout) {
+  process.stdout.write(escapeHtmlTextContent(helpChunk))
+}
+process.stdout.write('</pre>')

--- a/content/stylesheets/layout.css
+++ b/content/stylesheets/layout.css
@@ -140,6 +140,7 @@ img.inline {
 details summary {
   padding-left: 0.3em;
 }
+details pre,
 details .commands {
   margin-top: var(--smaller-space);
   margin-bottom: var(--smaller-space);

--- a/content/usage.html.hbs
+++ b/content/usage.html.hbs
@@ -14,7 +14,27 @@
       are a bunch of sample content directories
       <a href="https://github.com/mkantor/operator/blob/master/samples">in the repository</a>.
     </p>
-    <p>To learn more, run <code>operator --help</code> or <code>operator &lt;SUBCOMMAND&gt; --help</code>.</p>
+    <div class="group">
+      <p>
+        To learn more, use the <code>--help</code> option (alone or with a subcommand):
+      </p>
+      <details name="help">
+        <summary><code>operator --help</code></summary>
+        {{get "/_operator-help"}}
+      </details>
+      <details name="help">
+        <summary><code>operator eval --help</code></summary>
+        {{get "/_operator-help" subcommand="eval"}}
+      </details>
+      <details name="help">
+        <summary><code>operator get --help</code></summary>
+        {{get "/_operator-help" subcommand="get"}}
+      </details>
+      <details name="help">
+        <summary><code>operator serve --help</code></summary>
+        {{get "/_operator-help" subcommand="serve"}}
+      </details>
+    </div>
   </article>
 
   <article>


### PR DESCRIPTION
Here's what it looks like:

<img width="835" height="512" alt="Screenshot 2025-07-28 at 5 48 55 AM" src="https://github.com/user-attachments/assets/aa415f01-8ddb-4981-bf91-260f61f373e9" />
