### PR TITLE
Limit `--help` width to avoid horizontal scrolling.

### DIFF
--- a/content/_operator-help.html.mjs
+++ b/content/_operator-help.html.mjs
@@ -19,6 +19,11 @@ const childProcess = exec(
   subcommand === undefined
     ? `"${operatorPath}" --help`
     : `"${operatorPath}" "${subcommand}" --help`,
+  {
+    env: {
+      COLUMNS: 85, // This is tailored to the current design.
+    },
+  },
 )
 
 process.stdout.write('<pre>')


### PR DESCRIPTION
Now possible thanks to https://github.com/mkantor/operator/pull/131.